### PR TITLE
let admin remove halls and showtimes

### DIFF
--- a/src/routes/admin/manage-halls/+page.server.ts
+++ b/src/routes/admin/manage-halls/+page.server.ts
@@ -1,5 +1,6 @@
 import pkg from 'pg';
 const {Pool} = pkg;
+import type { RequestEvent } from '@sveltejs/kit';
 
 const pool = new Pool({
 	user: process.env.PGUSER,
@@ -22,3 +23,17 @@ export async function load() {
 		return { halls: [] }; // Rückgabe eines leeren Arrays bei Fehler
 	}
 }
+
+export const actions = {
+	delete: async ({ params }: RequestEvent) => {
+		// Sicherstellen, dass hall_id vorhanden ist
+		const { hall_id } = params as { hall_id: string };
+		try {
+			await pool.query('DELETE FROM cinema_halls WHERE hall_id = $1', [hall_id]);
+			return { success: true };
+		} catch (error) {
+			console.error('Fehler beim Löschen des Saals:', error);
+			return { success: false };
+		}
+	}
+};

--- a/src/routes/admin/manage-halls/+page.svelte
+++ b/src/routes/admin/manage-halls/+page.svelte
@@ -1,8 +1,29 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
+
 	export let data: { halls: { hall_id: number; name: string; capacity: number }[] };
 
+	// Zur Detailseite navigieren
+	function goToDetail(hall_id: number) {
+		goto(`/admin/manage-halls/${hall_id}`);
+	}
+
+	// Saal löschen
+	async function deleteHall(hall_id: number) {
+		const response = await fetch(`/admin/manage-halls/${hall_id}`, {
+			method: 'DELETE'
+		});
+
+		if (response.ok) {
+			// Seite neu laden, um die Liste zu aktualisieren
+			location.reload();
+		} else {
+			alert('Fehler beim Löschen des Saals.');
+		}
+	}
+
 	function goToCreateHall() {
-		window.location.href = '/admin/manage-halls/create-hall';
+		goto('/admin/manage-halls/create-hall');
 	}
 </script>
 
@@ -12,9 +33,14 @@
 	{#if data.halls.length > 0}
 		<ul class="hall-list">
 			{#each data.halls as hall}
-				<li class="hall-item">
+				<!-- svelte-ignore a11y-click-events-have-key-events -->
+				<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+				<li class="hall-item" on:click={() => goToDetail(hall.hall_id)}>
 					<p><strong>Name:</strong> {hall.name}</p>
 					<p><strong>Kapazität:</strong> {hall.capacity} Sitzplätze</p>
+					<button class="delete-btn" on:click|stopPropagation={() => deleteHall(hall.hall_id)}>
+						Saal löschen
+					</button>
 				</li>
 			{/each}
 		</ul>
@@ -44,6 +70,27 @@
 		margin-bottom: 10px;
 		border: 1px solid #ddd;
 		border-radius: 5px;
+		cursor: pointer;
+		transition: background-color 0.2s;
+	}
+
+	.hall-item:hover {
+		background-color: #e9ecef;
+	}
+
+	.delete-btn {
+		background-color: #dc3545;
+		color: white;
+		border: none;
+		padding: 5px 10px;
+		border-radius: 3px;
+		cursor: pointer;
+		font-size: 14px;
+		margin-top: 10px;
+	}
+
+	.delete-btn:hover {
+		background-color: #c82333;
 	}
 
 	.create-hall-btn {

--- a/src/routes/admin/manage-halls/[hall_id]/+page.svelte
+++ b/src/routes/admin/manage-halls/[hall_id]/+page.svelte
@@ -1,0 +1,14 @@
+<script>
+</script>
+
+<main>
+	<p>🚧</p>
+</main>
+
+<style>
+	p {
+		text-align: center;
+		font-size: 7rem;
+		margin-top: 2rem;
+	}
+</style>

--- a/src/routes/admin/manage-halls/[hall_id]/+server.ts
+++ b/src/routes/admin/manage-halls/[hall_id]/+server.ts
@@ -1,0 +1,26 @@
+import pkg from 'pg';
+import type { RequestHandler } from '@sveltejs/kit';
+
+const { Pool } = pkg;
+
+const pool = new Pool({
+    user: process.env.PGUSER,
+    host: process.env.PGHOST,
+    database: process.env.PGDATABASE,
+    password: process.env.PGPASSWORD,
+    port: 5432,
+    ssl: { rejectUnauthorized: false }
+});
+
+// DELETE-Methode für das Löschen eines Saals
+export const DELETE: RequestHandler = async ({ params }) => {
+    const { hall_id } = params;
+
+    try {
+        await pool.query('DELETE FROM cinema_halls WHERE hall_id = $1', [hall_id]);
+        return new Response(null, { status: 204 }); // Erfolgreich gelöscht
+    } catch (error) {
+        console.error('Fehler beim Löschen des Saals:', error);
+        return new Response('Fehler beim Löschen des Saals', { status: 500 });
+    }
+};

--- a/src/routes/admin/manage-screenings/+page.svelte
+++ b/src/routes/admin/manage-screenings/+page.svelte
@@ -1,80 +1,122 @@
 <script lang="ts">
-	export let data: {
-		showtimes: {
-			showtime_id: number;
-			showtime: string;
-			movie_title: string; // IMDB-ID wird als Titel verwendet
-			hall_name: string;
-		}[];
-	};
+    import { goto } from '$app/navigation';
 
-	function goToCreateScreening() {
-		window.location.href = '/admin/manage-screenings/create-screening';
-	}
+    export let data: {
+        showtimes: {
+            showtime_id: number;
+            showtime: string;
+            movie_title: string; // IMDB-ID wird als Titel verwendet
+            hall_name: string;
+        }[];
+    };
+
+    // Navigation zur Detailseite
+    function goToDetail(showtime_id: number) {
+        goto(`/admin/manage-screenings/${showtime_id}`);
+    }
+
+    // Vorstellung löschen
+    async function deleteShowtime(showtime_id: number) {
+        const response = await fetch(`/admin/manage-screenings/${showtime_id}`, {
+            method: 'DELETE',
+        });
+
+        if (response.ok) {
+            location.reload(); // Seite aktualisieren
+        } else {
+            alert('Fehler beim Löschen der Vorstellung.');
+        }
+    }
+
+    function goToCreateScreening() {
+        goto('/admin/manage-screenings/create-screening');
+    }
 </script>
 
 <main>
-	<h1>Alle Vorstellungen</h1>
+    <h1>Alle Vorstellungen</h1>
 
-	{#if data.showtimes.length > 0}
-		<ul class="showtime-list">
-			{#each data.showtimes as showtime}
-				<li class="showtime-item">
-					<p><strong>Film (IMDB-ID):</strong> {showtime.movie_title}</p>
-					<p><strong>Saal:</strong> {showtime.hall_name}</p>
-					<p><strong>Datum und Uhrzeit:</strong> {new Date(showtime.showtime).toLocaleString()}</p>
-				</li>
-			{/each}
-		</ul>
-	{:else}
-		<p>Es sind keine Vorstellungen vorhanden.</p>
-	{/if}
+    {#if data.showtimes.length > 0}
+        <ul class="showtime-list">
+            {#each data.showtimes as showtime}
+                <!-- svelte-ignore a11y-click-events-have-key-events -->
+                <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+                <li class="showtime-item" on:click={() => goToDetail(showtime.showtime_id)}>
+                    <p><strong>Film (IMDB-ID):</strong> {showtime.movie_title}</p>
+                    <p><strong>Saal:</strong> {showtime.hall_name}</p>
+                    <p><strong>Datum und Uhrzeit:</strong> {new Date(showtime.showtime).toLocaleString()}</p>
+                    <button 
+                        class="delete-btn" 
+                        on:click|stopPropagation={() => deleteShowtime(showtime.showtime_id)}>
+                        Vorstellung löschen
+                    </button>
+                </li>
+            {/each}
+        </ul>
+    {:else}
+        <p>Es sind keine Vorstellungen vorhanden.</p>
+    {/if}
 
-	<button class="create-showtime-btn" on:click={goToCreateScreening}>
-		Neue Vorstellung erstellen
-	</button>
+    <button class="create-showtime-btn" on:click={goToCreateScreening}>
+        Neue Vorstellung erstellen
+    </button>
 </main>
 
 <style>
-	h1 {
-		text-align: center;
-		margin-bottom: 20px;
-	}
+    h1 {
+        text-align: center;
+        margin-bottom: 20px;
+    }
 
-	.showtime-list {
-		list-style-type: none;
-		padding: 0;
-		max-width: 600px;
-		margin: 0 auto 20px;
-	}
+    .showtime-list {
+        list-style-type: none;
+        padding: 0;
+        max-width: 600px;
+        margin: 0 auto 20px;
+    }
 
-	.showtime-item {
-		background-color: #f9f9f9;
-		padding: 15px;
-		margin-bottom: 10px;
-		border: 1px solid #ddd;
-		border-radius: 5px;
-		box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-	}
+    .showtime-item {
+        background-color: #f9f9f9;
+        padding: 15px;
+        margin-bottom: 10px;
+        border: 1px solid #ddd;
+        border-radius: 5px;
+        cursor: pointer;
+        transition: background-color 0.2s;
+    }
 
-	.showtime-item p {
-		margin: 5px 0;
-	}
+    .showtime-item:hover {
+        background-color: #e9ecef;
+    }
 
-	.create-showtime-btn {
-		display: block;
-		margin: 20px auto;
-		padding: 10px 20px;
-		font-size: 16px;
-		background-color: #007bff;
-		color: white;
-		border: none;
-		border-radius: 5px;
-		cursor: pointer;
-		transition: background 0.3s ease;
-	}
+    .delete-btn {
+        background-color: #dc3545;
+        color: white;
+        border: none;
+        padding: 5px 10px;
+        border-radius: 3px;
+        cursor: pointer;
+        font-size: 14px;
+        margin-top: 10px;
+    }
 
-	.create-showtime-btn:hover {
-		background-color: #0056b3;
-	}
+    .delete-btn:hover {
+        background-color: #c82333;
+    }
+
+    .create-showtime-btn {
+        display: block;
+        margin: 20px auto;
+        padding: 10px 20px;
+        font-size: 16px;
+        background-color: #007bff;
+        color: white;
+        border: none;
+        border-radius: 5px;
+        cursor: pointer;
+    }
+
+    .create-showtime-btn:hover {
+        background-color: #0056b3;
+    }
 </style>

--- a/src/routes/admin/manage-screenings/[showtime_id]/+page.svelte
+++ b/src/routes/admin/manage-screenings/[showtime_id]/+page.svelte
@@ -1,0 +1,14 @@
+<script>
+</script>
+
+<main>
+	<p>🚧</p>
+</main>
+
+<style>
+	p {
+		text-align: center;
+		font-size: 7rem;
+		margin-top: 2rem;
+	}
+</style>

--- a/src/routes/admin/manage-screenings/[showtime_id]/+server.ts
+++ b/src/routes/admin/manage-screenings/[showtime_id]/+server.ts
@@ -1,0 +1,26 @@
+import pkg from 'pg';
+import type { RequestHandler } from '@sveltejs/kit';
+
+const { Pool } = pkg;
+
+const pool = new Pool({
+	user: process.env.PGUSER,
+	host: process.env.PGHOST,
+	database: process.env.PGDATABASE,
+	password: process.env.PGPASSWORD,
+	port: 5432,
+	ssl: { rejectUnauthorized: false }
+});
+
+// DELETE-Methode für das Löschen einer Vorstellung
+export const DELETE: RequestHandler = async ({ params }) => {
+	const { showtime_id } = params;
+
+	try {
+		await pool.query('DELETE FROM showtimes WHERE showtime_id = $1', [showtime_id]);
+		return new Response(null, { status: 204 }); // Erfolgreich gelöscht
+	} catch (error) {
+		console.error('Fehler beim Löschen der Vorstellung:', error);
+		return new Response('Fehler beim Löschen der Vorstellung', { status: 500 });
+	}
+};


### PR DESCRIPTION
## Description

the admin can now delete halls and showtimes directly from the pages 'admin/manage-halls' and 'admin/manage-screenings'. i added a delete button to each entry and made it clickable. the detail page will be implemented in a future issue, for now only the route is created.

this is how the halls look like:

<img width="653" alt="image" src="https://github.com/user-attachments/assets/98378c61-fe75-4d3e-8581-f96246672bb9" />

Closes #43 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
