### PR TITLE
feat: showtimes are now clickable and lead to detail page

### DIFF
--- a/src/routes/movies/[id]/+page.server.ts
+++ b/src/routes/movies/[id]/+page.server.ts
@@ -36,14 +36,25 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 
 	// Vorstellungen abrufen
 	const res = await client.query(
-		'SELECT showtime AS time, hall_id AS hall FROM showtimes WHERE movie_id = $1',
+		'SELECT showtime_id, showtime AS time, hall_id AS hall FROM showtimes WHERE movie_id = $1',
 		[id]
 	);
-
 	await client.end();
 
+	// showtime_id -> id mappen, damit "showtime.id" korrekt ist
+	const showtimes = res.rows.map((row) => {
+		return {
+			id: row.showtime_id,
+			time: row.time,
+			hall: row.hall
+		};
+	});
+
 	return {
-		movie: data,
-		showtimes: res.rows // Vorstellungen zurückgeben
+		movie: {
+			...data,
+			id 
+		},
+		showtimes
 	};
 };

--- a/src/routes/movies/[id]/+page.svelte
+++ b/src/routes/movies/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	export let data: { movie: any; showtimes: { time: string; hall: string }[] };
+	export let data: { movie: any; showtimes: { id: string; time: string; hall: string }[] };
 </script>
 
 <main>
@@ -40,15 +40,20 @@
 			<ul>
 				{#each data.showtimes as showtime}
 					<li class="showtime-card">
-						<strong>Zeit:</strong>
-						{new Date(showtime.time).toLocaleString('de-DE', {
-							weekday: 'short',
-							year: 'numeric',
-							month: 'short',
-							day: 'numeric',
-							hour: '2-digit',
-							minute: '2-digit'
-						})} Uhr | <strong>Saal:</strong> {showtime.hall} | <strong>Dauer:</strong> {data.movie.Runtime}
+						<a class="showtime-link" href={`/movies/${data.movie.id}/${showtime.id}`}>
+							<strong>Zeit:</strong>
+							{new Date(showtime.time).toLocaleString('de-DE', {
+								weekday: 'short',
+								year: 'numeric',
+								month: 'short',
+								day: 'numeric',
+								hour: '2-digit',
+								minute: '2-digit'
+							})} Uhr | <strong>Saal:</strong>
+							{showtime.hall}
+							| <strong>Dauer:</strong>
+							{data.movie.Runtime}
+						</a>
 					</li>
 				{/each}
 			</ul>
@@ -128,13 +133,23 @@
 		transition:
 			transform 0.3s ease,
 			box-shadow 0.3s ease;
+		position: relative; /* falls du damit arbeiten möchtest */
+		padding: 0; /* wir überlassen das Padding eher dem Link selbst */
 	}
 
-	.showtime-card:hover {
-		transform: translateY(-5px);
-		box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+	.showtime-link {
+		display: block; 
+		text-decoration: none; 
+		color: inherit; 
+		padding: 1rem; 
+		border-radius: 8px; 
+		transition: color 0.2s ease; 
 	}
 
+	.showtime-card:hover .showtime-link {
+		color: #2c3e50; /* z.B. dunkleres Blau beim Hover */
+		text-decoration: none; /* sicherstellen, dass nichts unterstrichen wird */
+	}
 	/* Responsive Design */
 	@media (max-width: 768px) {
 		.movie-details {

--- a/src/routes/movies/[id]/[showtime_id]/+page.svelte
+++ b/src/routes/movies/[id]/[showtime_id]/+page.svelte
@@ -1,0 +1,14 @@
+<script>
+</script>
+
+<main>
+	<p>🚧</p>
+</main>
+
+<style>
+    p {
+        text-align: center;
+        font-size: 8rem;
+        margin-top: 2rem;
+    }
+</style>


### PR DESCRIPTION
## Description
when clicking on a movie from the /movies page, every show time that is listed there is clickable and leads to a detail page. the detail page is yet to be implemented.

Fixes #50 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
