### PR TITLE
(admin) feat: booked seats in screenings tool

### DIFF
--- a/src/routes/admin/manage-screenings/[screening_id]/+page.svelte
+++ b/src/routes/admin/manage-screenings/[screening_id]/+page.svelte
@@ -117,7 +117,7 @@
 	function getSeatClass(seat: any) {
 		if (!seat) return 'seat-empty';
 		if (seat.status === 'inactive') return 'seat-inactive';
-		if (seat.status === 'booked') return 'booked'; // Check for booked status first
+		if (seat.isBooked) return 'booked';
 
 		const categoryLower = seat.category?.toLowerCase() || 'regular';
 		for (const [type, data] of Object.entries(seatTypes)) {

--- a/src/routes/admin/manage-screenings/[screening_id]/+page.svelte
+++ b/src/routes/admin/manage-screenings/[screening_id]/+page.svelte
@@ -483,6 +483,9 @@
 	.legend-box.disabled {
 		background-color: #86efac;
 	}
+	.legend-box.booked {
+		background-color: #9ca3af;
+	}
 
 	.modifier {
 		color: #666;

--- a/src/routes/admin/manage-screenings/[screening_id]/+page.svelte
+++ b/src/routes/admin/manage-screenings/[screening_id]/+page.svelte
@@ -12,7 +12,8 @@
 		vip: { modifier: 5.0, class: 'vip' },
 		premium: { modifier: 3.0, class: 'premium' },
 		regular: { modifier: 1.0, class: 'regular' },
-		disabled: { modifier: 0.8, class: 'disabled' }
+		disabled: { modifier: 0.8, class: 'disabled' },
+		booked: { modifier: 0.0, class: 'booked' } // Add booked status
 	};
 
 	// Movie search state
@@ -116,6 +117,7 @@
 	function getSeatClass(seat: any) {
 		if (!seat) return 'seat-empty';
 		if (seat.status === 'inactive') return 'seat-inactive';
+		if (seat.status === 'booked') return 'booked'; // Check for booked status first
 
 		const categoryLower = seat.category?.toLowerCase() || 'regular';
 		for (const [type, data] of Object.entries(seatTypes)) {
@@ -441,6 +443,11 @@
 	}
 	.seat.seat-empty {
 		visibility: hidden;
+	}
+	.seat.booked {
+		background-color: #9ca3af;
+		cursor: not-allowed;
+		color: #fff;
 	}
 
 	.seat-legend {


### PR DESCRIPTION
## Description

This pull request includes changes to the `src/routes/admin/manage-screenings/[screening_id]` files to **add the functionality of marking seats as booked**. The most important changes include adding the `is_booked` status to the seat data, updating the seat class logic to handle booked seats, and adjusting the seat legend and styles accordingly.

Enhancements to seat data and logic:

* `src/routes/admin/manage-screenings/[screening_id]/+page.server.ts`: Added a `CASE` statement to determine if a seat is booked and included the `is_booked` status in the seat data. ([src/routes/admin/manage-screenings/[screening_id]/+page.server.tsL67-R79](diffhunk://#diff-a8db813aa83fe1ffa45a165a0fa924b0718abf9ded45bf737ebb2f562079d868L67-R79), [src/routes/admin/manage-screenings/[screening_id]/+page.server.tsL81-R89](diffhunk://#diff-a8db813aa83fe1ffa45a165a0fa924b0718abf9ded45bf737ebb2f562079d868L81-R89))

Updates to seat display and styles:

* `src/routes/admin/manage-screenings/[screening_id]/+page.svelte`: Added a new seat type for booked seats with a modifier of 0.0 and a class of 'booked'. ([src/routes/admin/manage-screenings/[screening_id]/+page.svelteL15-R16](diffhunk://#diff-f831300741fd646a55e5792b8ee18bbbdda25e766d51c33a80bef677a30d910fL15-R16))
* `src/routes/admin/manage-screenings/[screening_id]/+page.svelte`: Updated the `getSeatClass` function to return the 'booked' class for booked seats. ([src/routes/admin/manage-screenings/[screening_id]/+page.svelteR120](diffhunk://#diff-f831300741fd646a55e5792b8ee18bbbdda25e766d51c33a80bef677a30d910fR120))
* `src/routes/admin/manage-screenings/[screening_id]/+page.svelte`: Added CSS styles for the 'booked' seat class and updated the seat legend to include the booked status. ([src/routes/admin/manage-screenings/[screening_id]/+page.svelteR447-R451](diffhunk://#diff-f831300741fd646a55e5792b8ee18bbbdda25e766d51c33a80bef677a30d910fR447-R451), [src/routes/admin/manage-screenings/[screening_id]/+page.svelteR486-R488](diffhunk://#diff-f831300741fd646a55e5792b8ee18bbbdda25e766d51c33a80bef677a30d910fR486-R488))

![image](https://github.com/user-attachments/assets/e1316e3d-8679-4965-940c-a8861666030a)

Closes #121 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
